### PR TITLE
Add initial bed/vcf file support

### DIFF
--- a/refgenie/asset_build_packages.py
+++ b/refgenie/asset_build_packages.py
@@ -530,4 +530,39 @@ asset_build_packages = {
         CONT: "databio/refgenie",
         CMD_LST: ["cp {blacklist} {asset_outfolder}/{genome}_blacklist.bed.gz"],
     },
+    "vcf": {
+        DESC: "Gene sequence variations in the VCF (Variant calling format).",
+        ASSETS: {
+            "vcf": "{genome}.vcf",
+            "zipped_vcf": "{genome}.vcf.gz",
+            "tbi": "{genome}.vcf.gz.tbi",
+            "csi": "{genome}.vcf.gz.csi",
+            "gzi": "{genome}.vcf.gz.gzi",
+            "idx": "{genome}.vcf.gz.idx",
+        },
+        REQ_FILES: [{KEY: "vcf", DESC: "VCF file."}],
+        REQ_ASSETS: [],
+        REQ_PARAMS: [],
+        CONT: "databio/refgenie",
+        CMD_LST: [
+            "cp {vcf} {asset_outfolder}/{vcf}",
+            "bgzip --force --stdout --index --index-name {asset_outfolder}/{vcf}.gz.gzi {asset_outfolder}/{vcf} > {asset_outfolder}/{vcf}.gz",
+            "tabix --force {asset_outfolder}/{vcf}.gz > {asset_outfolder}/{vcf}.gz.tbi",
+            "tabix --force --csi {asset_outfolder}/{vcf}.gz > {asset_outfolder}/{vcf}.gz.csi",
+            "rtg index {asset_outfolder}/{vcf}.gz > {asset_outfolder}/{vcf}.gz.idx"
+        ],
+    },
+    "bed": {
+        DESC: "Genomic regions as coordinates and associated annotations in the BED (Browser Extensible Data).",
+        ASSETS: {
+            "bed": "{genome}.bed",
+        },
+        REQ_FILES: [{KEY: "bed", DESC: "BED file."}],
+        REQ_ASSETS: [],
+        REQ_PARAMS: [],
+        CONT: "databio/refgenie",
+        CMD_LST: [
+            "cp {bed} {asset_outfolder}/{bed}",
+        ],
+    },
 }


### PR DESCRIPTION
This edit implements the support of vcf and bed files (See #245)
* It builds various index files for vcf files, needed by different bioinformatic tools.
* Different versions of bed files might be added with a tag.

However, I'm not sure how one would access the `zipped_vcf` from the vcf asset. Some tools might need the uncompressed vcf file and others will need the compressed one, but they are basically the same files. I think it would be counterintuitive to add two entries to `refgenie/asset_build_packages.py` for the same file. Is there a good solution for this or is there a way to access these (un)compressed files already?